### PR TITLE
fix: Handle Enter key properly in contentEditable editor

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -74,6 +74,14 @@ function Editor(props: EditorProps): JSX.Element {
     props.onChange(text);
   };
 
+  const handleKeyDown = (e: KeyboardEvent) => {
+    // Handle Enter key - insert line break
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      document.execCommand("insertLineBreak");
+    }
+  };
+
   createEffect(() => {
     if (!editorRef) return;
     const selection = window.getSelection();
@@ -122,6 +130,7 @@ function Editor(props: EditorProps): JSX.Element {
         contentEditable={true}
         spellcheck={props.settings.spellcheck}
         onInput={handleInput}
+        onKeyDown={handleKeyDown}
         class="w-full absolute h-screen overflow-y-auto overflow-x-hidden
                [word-break:break-word] text-black dark:text-white caret-blue-500
                bg-transparent [scrollbar-width:thin] scroll-smooth


### PR DESCRIPTION
## Summary

Fixes #9 - Enter key was broken while Shift+Enter worked correctly.

## Problem
In the contentEditable editor, pressing Enter did not insert a line break, but Shift+Enter worked as expected.

## Solution
Added a onKeyDown handler that intercepts the Enter key (without Shift) and uses document.execCommand('insertLineBreak') to insert a line break consistently.

## Changes
- Added handleKeyDown function in Editor.tsx
- Added onKeyDown event handler to the contentEditable div

## Testing
- Enter key now inserts line break correctly
- Shift+Enter still works as before

Fixes: #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced editor's Enter key behavior to insert line breaks when Shift is not held, providing better control over text input formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->